### PR TITLE
Check mutual communities for determining friends

### DIFF
--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -334,6 +334,7 @@
 		end
 
 		-- Check communities
+		print("name: \""..(name and name or "(nil)").."\"; guid: "..(guid and guid or "(nil)").."\"")
 		local cInfo = C_Club.GetSubscribedClubs()
 		for k, v in pairs(cInfo) do
 			local cMembers = C_Club.GetClubMembers(v.clubId)
@@ -341,7 +342,9 @@
 				local cMemberInfo = C_Club.GetMemberInfo(v.clubId, i)
 				if cMemberInfo and (cMemberInfo.presence == 1 or cMemberInfo.presence == 4 or cMemberInfo.presence == 5) then
 					local cName = strsplit("-", cMemberInfo.name, 2)
-					if (guid and cMemberInfo.guid == guid) or cName == name then
+					local matchFound = (guid and cMemberInfo.guid == guid) or cName == name
+					print((matchFound and "match found!" or "no match:").." cMemberInfo.guid: \""..(cMemberInfo.guid and cMemberInfo.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
+					if matchFound then
 						return true
 					end
 				end

--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -339,7 +339,7 @@
 			local cMembers = C_Club.GetClubMembers(v.clubId)
 			for i = 1, #cMembers do
 				local cMemberInfo = C_Club.GetMemberInfo(v.clubId, i)
-				if cMemberInfo.presence == 1 or cMemberInfo.presence == 4 or cMemberInfo.presence == 5 then
+				if cMemberInfo and (cMemberInfo.presence == 1 or cMemberInfo.presence == 4 or cMemberInfo.presence == 5) then
 					local cName = strsplit("-", cMemberInfo.name, 2)
 					if cName == name then
 						return true

--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -336,24 +336,24 @@
 		-- Check communities
 		print("invite received from: \""..(name and name or "(nil)").."\"; guid: "..(guid and guid or "(nil)").."\"")
 		local communities = C_Club.GetSubscribedClubs()
-		for k, community in pairs(communities) do
+		for ka, community in pairs(communities) do
 			if community.clubType == Enum.ClubType.Character then
 				print("community name: "..(community.name).."; clubId: "..(community.clubId and tostring(community.clubId) or "(nil)"))
-				local cMembers = C_Club.GetClubMembers(community.clubId)
-				print("community cMembers table: "..(cMembers and tostring(cMembers) or "(nil)").."")
-				for i = 1, #cMembers do
-					local cMemberInfo = C_Club.GetMemberInfo(community.clubId, i)
-					if cMemberInfo and cMemberInfo.presence ~= Enum.ClubMemberPresence.Offline and cMemberInfo.presence ~= Enum.ClubMemberPresence.OnlineMobile then
-						local cName = strsplit("-", cMemberInfo.name, 2)
-						local matchFound = (guid and (cMemberInfo.guid == guid)) or (cName == name)
-						print((matchFound and "match found!" or "no match:").." cMemberInfo.guid: \""..(cMemberInfo.guid and cMemberInfo.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
+				local cMemberIds = CommunitiesUtil.GetMemberIdsSortedByName(community.clubId)
+				local cMembersInfo = CommunitiesUtil.GetMemberInfo(community.clubId, cMemberIds)
+				print("community cMembers table: "..(cMembersInfo and tostring(cMembersInfo) or "(nil)"))
+				for kb, member in pairs(cMembersInfo) do
+					if member and member.presence ~= Enum.ClubMemberPresence.Offline and member.presence ~= Enum.ClubMemberPresence.OnlineMobile then
+						local cName = strsplit("-", member.name, 2)
+						local matchFound = (guid and (member.guid == guid)) or (cName == name)
+						print((matchFound and "match found!" or "no match:").." cMemberInfo.guid: \""..(member.guid and member.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
 						if matchFound then
 							return true
 						end
-					elseif cMemberInfo == nil then
-						print("cMemberInfo is nil for member number "..tostring(i))
+					elseif member == nil then
+						print("cMemberInfo is nil for member number "..tostring(member))
 					else
-						print("presence of "..(cMemberInfo.presence and tostring(cMemberInfo.presence) or "(nil)").." can't match: cMemberInfo.guid: \""..(cMemberInfo.guid and cMemberInfo.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
+						print("presence of "..(member.presence and tostring(member.presence) or "(nil)").." can't match: cMemberInfo.guid: \""..(member.guid and member.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
 					end
 				end
 			end

--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -300,9 +300,10 @@
 		-- Check character friends
 		for i = 1, C_FriendList.GetNumFriends() do
 			-- Return true if name matches with or without realm
-			local charFriendName = C_FriendList.GetFriendInfoByIndex(i).name
+			local friendInfo = C_FriendList.GetFriendInfoByIndex(i)
+			local charFriendName = friendInfo.name
 			charFriendName = strsplit("-", charFriendName, 2)
-			if name == charFriendName then
+			if (guid and (guid == friendInfo.guid)) or (name == charFriendName) then
 				return true
 			end
 		end
@@ -324,36 +325,27 @@
 		-- Check guild roster (new members may need to press J to refresh roster)
 		local gCount = GetNumGuildMembers()
 		for i = 1, gCount do
-			local gName, void, void, void, void, void, void, void, gOnline, void, void, void, void, gMobile = GetGuildRosterInfo(i)
+			local gName, void, void, void, void, void, void, void, gOnline, void, void, void, void, gMobile, void, void, gGUID = GetGuildRosterInfo(i)
 			if gOnline and not gMobile then
 				gName = strsplit("-", gName, 2)
-				if gName == name then
+				if (guid and (guid == gGUID)) or (name == gName) then
 					return true
 				end
 			end
 		end
 
 		-- Check communities
-		print("invite received from: \""..(name and name or "(nil)").."\"; guid: "..(guid and guid or "(nil)").."\"")
 		local communities = C_Club.GetSubscribedClubs()
 		for ka, community in pairs(communities) do
 			if community.clubType == Enum.ClubType.Character then
-				print("community name: "..(community.name).."; clubId: "..(community.clubId and tostring(community.clubId) or "(nil)"))
 				local cMemberIds = CommunitiesUtil.GetMemberIdsSortedByName(community.clubId)
 				local cMembersInfo = CommunitiesUtil.GetMemberInfo(community.clubId, cMemberIds)
-				print("community cMembers table: "..(cMembersInfo and tostring(cMembersInfo) or "(nil)"))
 				for kb, member in pairs(cMembersInfo) do
 					if member and member.presence ~= Enum.ClubMemberPresence.Offline and member.presence ~= Enum.ClubMemberPresence.OnlineMobile then
 						local cName = strsplit("-", member.name, 2)
-						local matchFound = (guid and (member.guid == guid)) or (cName == name)
-						print((matchFound and "match found!" or "no match:").." cMemberInfo.guid: \""..(member.guid and member.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
-						if matchFound then
+						if (guid and (guid == member.guid)) or (name == cName) then
 							return true
 						end
-					elseif member == nil then
-						print("cMemberInfo is nil for member number "..tostring(member))
-					else
-						print("presence of "..(member.presence and tostring(member.presence) or "(nil)").." can't match: cMemberInfo.guid: \""..(member.guid and member.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
 					end
 				end
 			end

--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -336,11 +336,11 @@
 		-- Check communities
 		local cInfo = C_Club.GetSubscribedClubs()
 		for k, v in pairs(cInfo) do
-			local cMembers = C_Club.GetClubMembers(v)
+			local cMembers = C_Club.GetClubMembers(v.clubId)
 			for i = 1, #cMembers do
-				local void, void, cName, void, cPresence, void, cGUID = C_Club.GetMemberInfo(i)
-				if cPresence ~= 0 and cPresence ~= 3 then
-					cName = strsplit("-", cName, 2)
+				local cMemberInfo = C_Club.GetMemberInfo(i)
+				if cMemberInfo.presence == 1 or cMemberInfo.presence == 4 or cMemberInfo.presence == 5 then
+					local cName = strsplit("-", cMemberInfo.name, 2)
 					if cName == name then
 						return true
 					end

--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -338,8 +338,9 @@
 		local communities = C_Club.GetSubscribedClubs()
 		for k, community in pairs(communities) do
 			if community.clubType == Enum.ClubType.Character then
-				print("community name: "..(community.name).."")
+				print("community name: "..(community.name).."; clubId: "..(community.clubId and tostring(community.clubId) or "(nil)"))
 				local cMembers = C_Club.GetClubMembers(community.clubId)
+				print("community cMembers table: "..(cMembers and tostring(cMembers) or "(nil)").."")
 				for i = 1, #cMembers do
 					local cMemberInfo = C_Club.GetMemberInfo(community.clubId, i)
 					if cMemberInfo and cMemberInfo.presence ~= Enum.ClubMemberPresence.Offline and cMemberInfo.presence ~= Enum.ClubMemberPresence.OnlineMobile then
@@ -349,6 +350,10 @@
 						if matchFound then
 							return true
 						end
+					elseif cMemberInfo == nil then
+						print("cMemberInfo is nil for member number "..tostring(i))
+					else
+						print("presence of "..(cMemberInfo.presence and tostring(cMemberInfo.presence) or "(nil)").." can't match: cMemberInfo.guid: \""..(cMemberInfo.guid and cMemberInfo.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
 					end
 				end
 			end

--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -338,7 +338,7 @@
 		for k, v in pairs(cInfo) do
 			local cMembers = C_Club.GetClubMembers(v.clubId)
 			for i = 1, #cMembers do
-				local cMemberInfo = C_Club.GetMemberInfo(i)
+				local cMemberInfo = C_Club.GetMemberInfo(v.clubId, i)
 				if cMemberInfo.presence == 1 or cMemberInfo.presence == 4 or cMemberInfo.presence == 5 then
 					local cName = strsplit("-", cMemberInfo.name, 2)
 					if cName == name then

--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -334,18 +334,21 @@
 		end
 
 		-- Check communities
-		print("name: \""..(name and name or "(nil)").."\"; guid: "..(guid and guid or "(nil)").."\"")
-		local cInfo = C_Club.GetSubscribedClubs()
-		for k, v in pairs(cInfo) do
-			local cMembers = C_Club.GetClubMembers(v.clubId)
-			for i = 1, #cMembers do
-				local cMemberInfo = C_Club.GetMemberInfo(v.clubId, i)
-				if cMemberInfo and (cMemberInfo.presence == 1 or cMemberInfo.presence == 4 or cMemberInfo.presence == 5) then
-					local cName = strsplit("-", cMemberInfo.name, 2)
-					local matchFound = (guid and cMemberInfo.guid == guid) or cName == name
-					print((matchFound and "match found!" or "no match:").." cMemberInfo.guid: \""..(cMemberInfo.guid and cMemberInfo.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
-					if matchFound then
-						return true
+		print("invite received from: \""..(name and name or "(nil)").."\"; guid: "..(guid and guid or "(nil)").."\"")
+		local communities = C_Club.GetSubscribedClubs()
+		for k, community in pairs(communities) do
+			if community.clubType == Enum.ClubType.Character then
+				print("community name: "..(community.name).."")
+				local cMembers = C_Club.GetClubMembers(community.clubId)
+				for i = 1, #cMembers do
+					local cMemberInfo = C_Club.GetMemberInfo(community.clubId, i)
+					if cMemberInfo and cMemberInfo.presence ~= Enum.ClubMemberPresence.Offline and cMemberInfo.presence ~= Enum.ClubMemberPresence.OnlineMobile then
+						local cName = strsplit("-", cMemberInfo.name, 2)
+						local matchFound = (guid and (cMemberInfo.guid == guid)) or (cName == name)
+						print((matchFound and "match found!" or "no match:").." cMemberInfo.guid: \""..(cMemberInfo.guid and cMemberInfo.guid or "(nil)").."\"; cName: \""..(cName and cName or "(nil)").."\"")
+						if matchFound then
+							return true
+						end
 					end
 				end
 			end

--- a/Leatrix_Plus.lua
+++ b/Leatrix_Plus.lua
@@ -285,7 +285,7 @@
 		end
 	end
 
-	-- Check if a name is in your friends list or guild (does not check realm as realm is unknown for some checks)
+	-- Check if a name is in your friends list, guild, or any of your communities (does not check realm as realm is unknown for some checks)
 	function LeaPlusLC:FriendCheck(name)
 
 		-- Do nothing if name is empty (such as whispering from the Battle.net app)
@@ -329,6 +329,21 @@
 				gName = strsplit("-", gName, 2)
 				if gName == name then
 					return true
+				end
+			end
+		end
+
+		-- Check communities
+		local cInfo = C_Club.GetSubscribedClubs()
+		for k, v in pairs(cInfo) do
+			local cMembers = C_Club.GetClubMembers(v)
+			for i = 1, #cMembers do
+				local void, void, cName, void, cPresence, void, cGUID = C_Club.GetMemberInfo(i)
+				if cPresence ~= 0 and cPresence ~= 3 then
+					cName = strsplit("-", cName, 2)
+					if cName == name then
+						return true
+					end
 				end
 			end
 		end


### PR DESCRIPTION
Players in mutual communities can be considered friends as well, and [this Reddit post](https://www.reddit.com/r/wowaddons/comments/qsdpiy/auto_accept_invite_popup_addon/) requested this feature.

I tested it together with the original poster of that post and it worked well, when the inviter was in a mutual community (auto-accept) and when they weren't (no auto-accept).

These changes also add the ability to scan by GUID, which is a more precise way to scan than name, though it still maintains the name scanning, so a mismatch is still possible, but that's a very rare edge case that already existed in the code base.

Feel free to make or request any changes before merging.  Thanks for your awesome addon.